### PR TITLE
Add bucket connection details secret with extra fields

### DIFF
--- a/generate_sample.go
+++ b/generate_sample.go
@@ -62,6 +62,10 @@ func newBucketSample() *exoscalev1.Bucket {
 		ObjectMeta: metav1.ObjectMeta{Name: "bucket"},
 		Spec: exoscalev1.BucketSpec{
 			ResourceSpec: xpv1.ResourceSpec{
+				WriteConnectionSecretToReference: &xpv1.SecretReference{
+					Name:      "bucket-credential-secret",
+					Namespace: "default",
+				},
 				ProviderConfigReference: &xpv1.Reference{Name: "provider-config"},
 			},
 			ForProvider: exoscalev1.BucketParameters{

--- a/operator/bucketcontroller/observe.go
+++ b/operator/bucketcontroller/observe.go
@@ -2,11 +2,11 @@ package bucketcontroller
 
 import (
 	"context"
-
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
+	exoscalev1 "github.com/vshn/provider-exoscale/apis/exoscale/v1"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 )
 
@@ -25,7 +25,15 @@ func (p *ProvisioningPipeline) Observe(ctx context.Context, mg resource.Managed)
 	if exists {
 		bucket.Status.AtProvider.BucketName = bucketName
 		bucket.SetConditions(xpv1.Available())
-		return managed.ExternalObservation{ResourceExists: true, ResourceUpToDate: true}, nil
+		return managed.ExternalObservation{ResourceExists: true, ResourceUpToDate: true, ConnectionDetails: toConnectionDetails(bucket)}, nil
 	}
 	return managed.ExternalObservation{}, nil
+}
+
+func toConnectionDetails(bucket *exoscalev1.Bucket) managed.ConnectionDetails {
+	return map[string][]byte{
+		EndpointName: []byte(bucket.Spec.ForProvider.EndpointURL),
+		ZoneName:     []byte(bucket.Spec.ForProvider.Zone),
+		BucketName:   []byte(bucket.Spec.ForProvider.BucketName),
+	}
 }

--- a/operator/bucketcontroller/pipeline.go
+++ b/operator/bucketcontroller/pipeline.go
@@ -3,11 +3,21 @@ package bucketcontroller
 import (
 	"context"
 	exoscalev1 "github.com/vshn/provider-exoscale/apis/exoscale/v1"
+	corev1 "k8s.io/api/core/v1"
 
 	"github.com/crossplane/crossplane-runtime/pkg/event"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/minio/minio-go/v7"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	// EndpointName is the endpoint field name in credential secret
+	EndpointName = "ENDPOINT"
+	// ZoneName is the region field name in credential secret
+	ZoneName = "ZONE"
+	// BucketName is the bucket field name in credential secret
+	BucketName = "BUCKET_NAME"
 )
 
 // ProvisioningPipeline provisions Buckets using S3 client.
@@ -19,7 +29,8 @@ type ProvisioningPipeline struct {
 
 type pipelineContext struct {
 	context.Context
-	bucket *exoscalev1.Bucket
+	bucket                 *exoscalev1.Bucket
+	IAMKeyCredentialSecret *corev1.Secret
 }
 
 // NewProvisioningPipeline returns a new instance of ProvisioningPipeline.

--- a/operator/bucketcontroller/webhook.go
+++ b/operator/bucketcontroller/webhook.go
@@ -21,7 +21,11 @@ func (v *BucketValidator) ValidateCreate(_ context.Context, obj runtime.Object) 
 
 	providerConfigRef := bucket.Spec.ProviderConfigReference
 	if providerConfigRef == nil || providerConfigRef.Name == "" {
-		return fmt.Errorf(".spec.providerConfigRef.name is required")
+		return fmt.Errorf(".spec.providerConfigRef name is required")
+	}
+	connectionSecretRef := bucket.Spec.WriteConnectionSecretToReference
+	if connectionSecretRef == nil || connectionSecretRef.Name == "" || connectionSecretRef.Namespace == "" {
+		return fmt.Errorf(".spec.writeConnectionSecretToReference name and namespace are required")
 	}
 	return nil
 }
@@ -44,7 +48,12 @@ func (v *BucketValidator) ValidateUpdate(_ context.Context, oldObj, newObj runti
 	}
 	providerConfigRef := newBucket.Spec.ProviderConfigReference
 	if providerConfigRef == nil || providerConfigRef.Name == "" {
-		return fmt.Errorf(".spec.providerConfigRef.name is required")
+		return fmt.Errorf(".spec.providerConfigRef name is required")
+	}
+	newConnectionSecretRef := newBucket.Spec.WriteConnectionSecretToReference
+	oldConnectionSecretRef := oldBucket.Spec.WriteConnectionSecretToReference
+	if newConnectionSecretRef == nil || newConnectionSecretRef.Name != oldConnectionSecretRef.Name || newConnectionSecretRef.Namespace != oldConnectionSecretRef.Namespace {
+		return fmt.Errorf(".spec.writeConnectionSecretToReference name and namespace cannot be changed")
 	}
 	return nil
 }

--- a/operator/iamkeycontroller/webhook.go
+++ b/operator/iamkeycontroller/webhook.go
@@ -25,12 +25,12 @@ func (v *IAMKeyValidator) ValidateCreate(_ context.Context, obj runtime.Object) 
 	}
 	secretRef := iamKey.Spec.WriteConnectionSecretToReference
 	if secretRef == nil || secretRef.Name == "" || secretRef.Namespace == "" {
-		return fmt.Errorf(".spec.writeConnectionSecretToRef.name and .spec.writeConnectionSecretToRef.namespace are required")
+		return fmt.Errorf(".spec.writeConnectionSecretToRef name and namespace are required")
 	}
 
 	providerConfigRef := iamKey.Spec.ProviderConfigReference
 	if providerConfigRef == nil || providerConfigRef.Name == "" {
-		return fmt.Errorf(".spec.providerConfigRef.name is required")
+		return fmt.Errorf(".spec.providerConfigRef name is required")
 	}
 	return nil
 }
@@ -53,7 +53,7 @@ func (v *IAMKeyValidator) ValidateUpdate(_ context.Context, oldObj, newObj runti
 	}
 	providerConfigRef := newIAMKey.Spec.ProviderConfigReference
 	if providerConfigRef == nil || providerConfigRef.Name == "" {
-		return fmt.Errorf(".spec.providerConfigRef.name is required")
+		return fmt.Errorf(".spec.providerConfigRef name is required")
 	}
 	return nil
 }

--- a/operator/iamkeycontroller/webhook_test.go
+++ b/operator/iamkeycontroller/webhook_test.go
@@ -71,23 +71,23 @@ func TestIAMKeyValidator_ValidateCreate_RequireWriteConnectionSecretToRef(t *tes
 		},
 		"GivenIAMKey_WhenWriteConnectionSecretToRefMissing_ThenExpectError": {
 			connectionSecretToRef: &xpv1.SecretReference{},
-			expectedError:         ".spec.writeConnectionSecretToRef.name and .spec.writeConnectionSecretToRef.namespace are required",
+			expectedError:         ".spec.writeConnectionSecretToRef name and namespace are required",
 		},
 		"GivenIAMKey_WhenWriteConnectionSecretToRefNameMissing_ThenExpectError": {
 			connectionSecretToRef: &xpv1.SecretReference{
 				Namespace: "secret-namespace",
 			},
-			expectedError: ".spec.writeConnectionSecretToRef.name and .spec.writeConnectionSecretToRef.namespace are required",
+			expectedError: ".spec.writeConnectionSecretToRef name and namespace are required",
 		},
 		"GivenIAMKey_WhenWriteConnectionSecretToRefNamespaceMissing_ThenExpectError": {
 			connectionSecretToRef: &xpv1.SecretReference{
 				Name: "secret-name",
 			},
-			expectedError: ".spec.writeConnectionSecretToRef.name and .spec.writeConnectionSecretToRef.namespace are required",
+			expectedError: ".spec.writeConnectionSecretToRef name and namespace are required",
 		},
 		"GivenIAMKey_WhenWriteConnectionSecretToRefIsNil_ThenExpectError": {
 			connectionSecretToRef: nil,
-			expectedError:         ".spec.writeConnectionSecretToRef.name and .spec.writeConnectionSecretToRef.namespace are required",
+			expectedError:         ".spec.writeConnectionSecretToRef name and namespace are required",
 		},
 	}
 	for name, tc := range tests {
@@ -130,17 +130,17 @@ func TestIAMKeyValidator_ValidateCreate_RequireProviderConfigToRef(t *testing.T)
 		},
 		"GivenIAMKey_WhenWriteConnectionSecretToRefMissing_ThenExpectError": {
 			providerConfigToRef: &xpv1.Reference{},
-			expectedError:       ".spec.providerConfigRef.name is required",
+			expectedError:       ".spec.providerConfigRef name is required",
 		},
 		"GivenIAMKey_WhenWriteConnectionSecretToRefNameMissing_ThenExpectError": {
 			providerConfigToRef: &xpv1.Reference{
 				Name: "",
 			},
-			expectedError: ".spec.providerConfigRef.name is required",
+			expectedError: ".spec.providerConfigRef name is required",
 		},
 		"GivenIAMKey_WhenWriteConnectionSecretToRefNameIsNil_ThenExpectError": {
 			providerConfigToRef: nil,
-			expectedError:       ".spec.providerConfigRef.name is required",
+			expectedError:       ".spec.providerConfigRef name is required",
 		},
 	}
 	for name, tc := range tests {
@@ -185,13 +185,13 @@ func TestIAMKeyValidator_ValidateUpdate_RequireProviderConfigToRef(t *testing.T)
 		},
 		"GivenUpdatedIAMKey_WhenWriteConnectionSecretToRefMissing_ThenExpectError": {
 			providerConfigToRef: &xpv1.Reference{},
-			expectedError:       ".spec.providerConfigRef.name is required",
+			expectedError:       ".spec.providerConfigRef name is required",
 		},
 		"GivenUpdatedIAMKey_WhenWriteConnectionSecretToRefNameMissing_ThenExpectError": {
 			providerConfigToRef: &xpv1.Reference{
 				Name: "",
 			},
-			expectedError: ".spec.providerConfigRef.name is required",
+			expectedError: ".spec.providerConfigRef name is required",
 		},
 	}
 	for name, tc := range tests {

--- a/samples/exoscale.crossplane.io_bucket.yaml
+++ b/samples/exoscale.crossplane.io_bucket.yaml
@@ -11,5 +11,8 @@ spec:
     zone: ch-gva-2
   providerConfigRef:
     name: provider-config
+  writeConnectionSecretToRef:
+    name: bucket-credential-secret
+    namespace: default
 status:
   atProvider: {}

--- a/test/e2e/provider/01-assert.yaml
+++ b/test/e2e/provider/01-assert.yaml
@@ -5,6 +5,7 @@ kind: TestAssert
 apiVersion: exoscale.crossplane.io/v1
 kind: Bucket
 metadata:
+  name: e2e-test-bucket
   annotations:
     kuttl: '01-install'
 spec:
@@ -16,6 +17,9 @@ spec:
     zone: ch-gva-2
   providerConfigRef:
     name: provider-config
+  writeConnectionSecretToRef:
+    name: exoscale-bucket-credentials-kuttl-test
+    namespace: e2e-test
 status:
   atProvider:
     bucketName: provider-exoscale-e2e-test-kuttl
@@ -27,3 +31,13 @@ status:
       status: 'True'
       type: Synced
 ---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: exoscale-bucket-credentials-kuttl-test
+  namespace: e2e-test
+data:
+  BUCKET_NAME: cHJvdmlkZXItZXhvc2NhbGUtZTJlLXRlc3Qta3V0dGw=
+  ENDPOINT: c29zLWNoLWd2YS0yLmV4by5pbw==
+  ZONE: Y2gtZ3ZhLTI=
+type: connection.crossplane.io/v1alpha1

--- a/test/e2e/provider/01-install-bucket.yaml
+++ b/test/e2e/provider/01-install-bucket.yaml
@@ -13,4 +13,7 @@ spec:
     zone: ch-gva-2
   providerConfigRef:
     name: provider-config
+  writeConnectionSecretToRef:
+    name: exoscale-bucket-credentials-kuttl-test
+    namespace: e2e-test
 ---

--- a/test/e2e/provider/10-delete.yaml
+++ b/test/e2e/provider/10-delete.yaml
@@ -7,4 +7,4 @@ delete:
     name: iam-key-kuttl-test
   - apiVersion: exoscale.crossplane.io/v1
     kind: Bucket
-    name: provider-exoscale-e2e-test-kuttl
+    name: e2e-test-bucket


### PR DESCRIPTION
## Summary

* Expose bucket connection details secret with Endpoint, Zone and bucket name.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
