### PR TITLE
Fix IAMkeys allowed operations

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -12,6 +12,7 @@
 //* xref:references/example.adoc[Example Reference]
 
 .Explanation
+* xref:explanations/iamkey.adoc[IAMKeys permissions]
 * For Developers
 ** xref:explanations/dev/iamkey-reconciliation.adoc[ObjectsUser Reconciliation]
 ** xref:explanations/dev/bucket-reconciliation.adoc[Bucket Reconciliation]

--- a/docs/modules/ROOT/pages/explanations/iamkey.adoc
+++ b/docs/modules/ROOT/pages/explanations/iamkey.adoc
@@ -1,0 +1,20 @@
+== IAMKeys permissions
+
+The IAMKeys have restricted access to exoscale API.
+The Object Storage `sos` service is the only service the keys have access to.
+The following are the allowed operations on buckets:
+
+- abort-sos-multipart-upload
+- delete-sos-object
+- get-sos-bucket-acl
+- get-sos-bucket-cors
+- get-sos-bucket-location
+- get-sos-object
+- get-sos-object-acl
+- get-sos-presigned-url
+- list-sos-bucket
+- list-sos-bucket-multipart-uploads
+- put-sos-bucket-acl
+- put-sos-bucket-cors
+- put-sos-object
+- put-sos-object-acl

--- a/operator/iamkeycontroller/pipeline.go
+++ b/operator/iamkeycontroller/pipeline.go
@@ -21,6 +21,23 @@ const (
 	SOSResourceDomain = "sos"
 )
 
+var IAMKeyAllowedOperations = []string{
+	"abort-sos-multipart-upload",
+	"delete-sos-object",
+	"get-sos-bucket-acl",
+	"get-sos-bucket-cors",
+	"get-sos-bucket-location",
+	"get-sos-object",
+	"get-sos-object-acl",
+	"get-sos-presigned-url",
+	"list-sos-bucket",
+	"list-sos-bucket-multipart-uploads",
+	"put-sos-object",
+	"put-sos-object-acl",
+	"put-sos-bucket-acl",
+	"put-sos-bucket-cors",
+}
+
 // IAMKeyPipeline provisions IAMKeys on exoscale.com
 type IAMKeyPipeline struct {
 	kube           client.Client


### PR DESCRIPTION
## Summary

* Added the list of bucket operations that the IAMKeys should have access to.
* Update the docs

Currently there is a bug in the Exoscale backend where several `list-*` operations are not working as intended. As soon as the S3 provider will fix the issue I will add the remaining operations.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
