### PR TITLE
Ensure e2e test resources are cleaned up

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,6 +10,7 @@
       as they show up in the changelog
 - [ ] Update tests.
 - [ ] Link this PR to related issues.
+- [ ] I have run `make test-e2e` and e2e tests pass successfully
 
 <!--
 Remove items that do not apply. For completed items, change [ ] to [x].

--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,6 @@ run-operator: ## Run in Operator mode against your current kube context
 	go run . -v 1 operator
 
 .PHONY: clean
-clean: kind-clean .package-clean .envtest-clean .e2e-test-clean ## Cleans local build artifacts
+clean: .e2e-test-clean .package-clean .envtest-clean kind-clean ## Cleans local build artifacts
 	rm -rf docs/node_modules $(docs_out_dir) dist .cache .work
 	$(DOCKER_CMD) rmi $(CONTAINER_IMG) || true

--- a/test/e2e/provider/00-assert.yaml
+++ b/test/e2e/provider/00-assert.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   deletionPolicy: Delete
   forProvider:
-    bucketName: e2e-test-bucket
+    bucketName: e2e-test-kuttl-provider-exoscale
     bucketDeletionPolicy: DeleteAll
     endpointURL: sos-ch-gva-2.exo.io
     zone: ch-gva-2
@@ -18,7 +18,7 @@ spec:
     name: provider-config
 status:
   atProvider:
-    bucketName: e2e-test-bucket
+    bucketName: e2e-test-kuttl-provider-exoscale
   conditions:
     - reason: Available
       status: "True"

--- a/test/e2e/provider/00-install-bucket.yaml
+++ b/test/e2e/provider/00-install-bucket.yaml
@@ -7,7 +7,7 @@ metadata:
   name: e2e-test-bucket
 spec:
   forProvider:
-    bucketName: e2e-test-bucket
+    bucketName: e2e-test-kuttl-provider-exoscale
     bucketDeletionPolicy: DeleteAll
     endpointURL: sos-ch-gva-2.exo.io
     zone: ch-gva-2

--- a/test/e2e/provider/02-upload.yaml
+++ b/test/e2e/provider/02-upload.yaml
@@ -3,4 +3,4 @@ kind: TestStep
 commands:
   # note: working dir is the where the yaml files are
   # Args: $endpoint $bucket $file_path $secret_name
-  - command: ../upload-object.sh sos-ch-gva-2.exo.io e2e-test-bucket ../../../README.md api-secret
+  - command: ../upload-object.sh sos-ch-gva-2.exo.io e2e-test-kuttl-provider-exoscale ../../../README.md api-secret


### PR DESCRIPTION
## Summary

* Affects local dev and GH actions
* running `make clean` now deletes any leftover buckets if the cluster is running
* See also https://github.com/vshn/provider-cloudscale/pull/38


## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [x] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
