### PR TITLE
 Schedule e2e test run for each day

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,6 +6,8 @@ on:
       - master
     paths-ignore:
       - docs/**
+  schedule:
+    - cron: 37 10 * * 1-5 # At 10:37 on every day-of-week from Monday through Friday
 
 jobs:
   test-e2e:

--- a/README.md
+++ b/README.md
@@ -66,5 +66,11 @@ To test and troubleshoot the webhooks on the cluster, simply apply your changes 
 
 ### Crossplane Provider Mechanics
 
-For detailed information on how Crossplane Provider works from a development perspective check [provider mechanics documentation page](https://kb.vshn.ch/app-catalog/explanations/crossplane_provider_mechanics.html). 
+For detailed information on how Crossplane Provider works from a development perspective check [provider mechanics documentation page](https://kb.vshn.ch/app-catalog/explanations/crossplane_provider_mechanics.html).
 
+### Cleaning up e2e tests
+
+Usually `make clean` ensures that buckets and users are deleted before deleting the kind cluster, provided the operator is running in kind cluster.
+Alternatively, `make .e2e-test-clean` also removes all `buckets` and `iamkeys`.
+
+To cleanup manually on portal.exoscale.com, search for resources that begin with or contain `e2e` in the name.


### PR DESCRIPTION
## Summary

Adds a cron schedule to run e2e test each day. This is to ensure that cloud provider's API are usable, and to ensure that e2e test resources from previous failed attempts are cleaned up to not incur cost.

See also: https://github.com/vshn/provider-cloudscale/pull/41

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [x] Link this PR to related issues.
- [ ] I have run `make test-e2e` and e2e tests pass successfully

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
