### PR TITLE
Better errors and prevent adoption of existing buckets

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -41,7 +41,7 @@ func LogMetadata(c *cli.Context) error {
 }
 
 func setupLogging(c *cli.Context) error {
-	logger := newZapLogger(appName, c.Bool("debug"), usesProductionLoggingConfig(c))
+	logger := newZapLogger(appName, c.Int("log-level"), usesProductionLoggingConfig(c))
 	c.Context.Value(loggerContextKey{}).(*atomic.Value).Store(logger)
 	return nil
 }
@@ -50,16 +50,16 @@ func usesProductionLoggingConfig(c *cli.Context) bool {
 	return strings.EqualFold("JSON", c.String("log-format"))
 }
 
-func newZapLogger(name string, debug bool, useProductionConfig bool) logr.Logger {
+func newZapLogger(name string, verbosityLevel int, useProductionConfig bool) logr.Logger {
 	cfg := zap.NewDevelopmentConfig()
 	cfg.EncoderConfig.ConsoleSeparator = " | "
 	if useProductionConfig {
 		cfg = zap.NewProductionConfig()
 	}
-	if debug {
+	if verbosityLevel > 0 {
 		// Zap's levels get more verbose as the number gets smaller,
 		// bug logr's level increases with greater numbers.
-		cfg.Level = zap.NewAtomicLevelAt(zapcore.Level(-2)) // max logger.V(2)
+		cfg.Level = zap.NewAtomicLevelAt(zapcore.Level(verbosityLevel * -1))
 	} else {
 		cfg.Level = zap.NewAtomicLevelAt(zapcore.InfoLevel)
 	}

--- a/main.go
+++ b/main.go
@@ -45,10 +45,9 @@ func newApp() (context.Context, context.CancelFunc, *cli.App) {
 	logInstance := &atomic.Value{}
 	logInstance.Store(logr.Discard())
 	app := &cli.App{
-		Name:     appName,
-		Usage:    appLongName,
-		Version:  fmt.Sprintf("%s, revision=%s, date=%s", version, commit, date),
-		Compiled: compilationDate(),
+		Name:    appName,
+		Usage:   appLongName,
+		Version: fmt.Sprintf("%s, revision=%s, date=%s", version, commit, date),
 
 		EnableBashCompletion: true,
 
@@ -106,13 +105,4 @@ func envVars(suffixes ...string) []string {
 		arr[i] = env(suffixes[i])
 	}
 	return arr
-}
-
-func compilationDate() time.Time {
-	compiled, err := time.Parse(time.RFC3339, date)
-	if err != nil {
-		// an empty Time{} causes cli.App to guess it from binary's file timestamp.
-		return time.Time{}
-	}
-	return compiled
 }

--- a/main.go
+++ b/main.go
@@ -96,7 +96,7 @@ func rootAction(hasSubcommands bool) func(context *cli.Context) error {
 
 // env combines envPrefix with given suffix delimited by underscore.
 func env(suffix string) string {
-	return envPrefix + "_" + suffix
+	return envPrefix + suffix
 }
 
 // envVars combines envPrefix with each given suffix delimited by underscore.

--- a/operator/bucketcontroller/create.go
+++ b/operator/bucketcontroller/create.go
@@ -2,6 +2,7 @@ package bucketcontroller
 
 import (
 	"context"
+
 	pipeline "github.com/ccremer/go-command-pipeline"
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/pkg/event"
@@ -23,6 +24,7 @@ func (p *ProvisioningPipeline) Create(ctx context.Context, mg resource.Managed) 
 	pipe.WithBeforeHooks(pipelineutil.DebugLogger(pctx)).
 		WithSteps(
 			pipe.NewStep("create bucket", p.createS3Bucket),
+			pipe.NewStep("set lock", p.setLock),
 			pipe.NewStep("emit event", p.emitCreationEvent),
 		)
 	err := pipe.RunWithContext(pctx)
@@ -48,7 +50,16 @@ func (p *ProvisioningPipeline) createS3Bucket(ctx *pipelineContext) error {
 		}
 	}
 	return nil
+}
 
+// setLock sets an annotation that tells the Observe func that we have successfully created the bucket.
+// Without it, another resource that has the same bucket name might "adopt" the same bucket, causing 2 resources managing 1 bucket.
+func (p *ProvisioningPipeline) setLock(ctx *pipelineContext) error {
+	if ctx.bucket.Annotations == nil {
+		ctx.bucket.Annotations = map[string]string{}
+	}
+	ctx.bucket.Annotations[lockAnnotation] = "claimed"
+	return nil
 }
 
 func (p *ProvisioningPipeline) emitCreationEvent(ctx *pipelineContext) error {

--- a/operator/bucketcontroller/observe.go
+++ b/operator/bucketcontroller/observe.go
@@ -2,13 +2,20 @@ package bucketcontroller
 
 import (
 	"context"
+	"fmt"
+	"net/http"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
+	"github.com/minio/minio-go/v7"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 )
+
+var bucketExistsFn = func(ctx context.Context, mc *minio.Client, bucketName string) (bool, error) {
+	return mc.BucketExists(ctx, bucketName)
+}
 
 // Observe implements managed.ExternalClient.
 func (p *ProvisioningPipeline) Observe(ctx context.Context, mg resource.Managed) (managed.ExternalObservation, error) {
@@ -18,14 +25,23 @@ func (p *ProvisioningPipeline) Observe(ctx context.Context, mg resource.Managed)
 	bucket := fromManaged(mg)
 
 	bucketName := bucket.GetBucketName()
-	exists, err := p.minioClient.BucketExists(ctx, bucketName)
+	exists, err := bucketExistsFn(ctx, p.minioClient, bucketName)
 	if err != nil {
+		errResp := minio.ToErrorResponse(err)
+		if errResp.StatusCode == http.StatusForbidden {
+			return managed.ExternalObservation{}, errors.Wrap(err, "wrong credentials or bucket exists already, try changing bucket name")
+		}
+		if errResp.StatusCode == http.StatusMovedPermanently {
+			return managed.ExternalObservation{}, errors.Wrap(err, "mismatching endpointURL and zone, or bucket exists already in a different region, try changing bucket name")
+		}
 		return managed.ExternalObservation{}, errors.Wrap(err, "cannot determine whether bucket exists")
 	}
-	if exists {
+	if _, hasAnnotation := bucket.Annotations[lockAnnotation]; hasAnnotation && exists {
 		bucket.Status.AtProvider.BucketName = bucketName
 		bucket.SetConditions(xpv1.Available())
 		return managed.ExternalObservation{ResourceExists: true, ResourceUpToDate: true}, nil
+	} else if exists {
+		return managed.ExternalObservation{}, fmt.Errorf("bucket exists already, try changing bucket name: %s", bucketName)
 	}
 	return managed.ExternalObservation{}, nil
 }

--- a/operator/bucketcontroller/observe_test.go
+++ b/operator/bucketcontroller/observe_test.go
@@ -1,0 +1,104 @@
+package bucketcontroller
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/crossplane/crossplane-runtime/pkg/errors"
+	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
+	"github.com/go-logr/logr"
+	"github.com/minio/minio-go/v7"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	exoscalev1 "github.com/vshn/provider-exoscale/apis/exoscale/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestProvisioningPipeline_Observe(t *testing.T) {
+	tests := map[string]struct {
+		givenBucket  *exoscalev1.Bucket
+		bucketExists bool
+		returnError  error
+
+		expectedError             string
+		expectedResult            managed.ExternalObservation
+		expectedBucketObservation exoscalev1.BucketObservation
+	}{
+		"NewBucketDoesntYetExistOnExoscale": {
+			givenBucket: &exoscalev1.Bucket{Spec: exoscalev1.BucketSpec{ForProvider: exoscalev1.BucketParameters{
+				BucketName: "my-bucket"}},
+			},
+			expectedResult: managed.ExternalObservation{},
+		},
+		"BucketExistsAndAccessibleWithOurCredentials": {
+			givenBucket: &exoscalev1.Bucket{
+				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+					lockAnnotation: "claimed",
+				}},
+				Spec: exoscalev1.BucketSpec{ForProvider: exoscalev1.BucketParameters{
+					BucketName: "my-bucket"}},
+			},
+			bucketExists:              true,
+			expectedResult:            managed.ExternalObservation{ResourceExists: true, ResourceUpToDate: true},
+			expectedBucketObservation: exoscalev1.BucketObservation{BucketName: "my-bucket"},
+		},
+		"NewBucketObservationThrowsGenericError": {
+			givenBucket: &exoscalev1.Bucket{Spec: exoscalev1.BucketSpec{ForProvider: exoscalev1.BucketParameters{
+				BucketName: "my-bucket"}},
+			},
+			returnError:    errors.New("error"),
+			expectedResult: managed.ExternalObservation{},
+			expectedError:  "cannot determine whether bucket exists: error",
+		},
+		"BucketAlreadyExistsOnExoscale_WithoutAccess": {
+			givenBucket: &exoscalev1.Bucket{Spec: exoscalev1.BucketSpec{ForProvider: exoscalev1.BucketParameters{
+				BucketName: "my-bucket"}},
+			},
+			returnError:    minio.ErrorResponse{StatusCode: http.StatusForbidden, Message: "Access Denied"},
+			expectedResult: managed.ExternalObservation{},
+			expectedError:  "wrong credentials or bucket exists already, try changing bucket name: Access Denied",
+		},
+		"BucketAlreadyExistsOnExoscale_WithAccess_PreventAdoption": {
+			// this is a case where we should avoid adopting an existing bucket even if we have access.
+			// Otherwise, there could be multiple K8s resources that manage the same bucket.
+			givenBucket: &exoscalev1.Bucket{
+				Spec: exoscalev1.BucketSpec{ForProvider: exoscalev1.BucketParameters{
+					BucketName: "my-bucket"}},
+				// no bucket name in status here.
+			},
+			bucketExists:   true,
+			expectedResult: managed.ExternalObservation{},
+			expectedError:  "bucket exists already, try changing bucket name: my-bucket",
+		},
+		"BucketAlreadyExistsOnExoscale_InAnotherZone": {
+			givenBucket: &exoscalev1.Bucket{
+				Spec: exoscalev1.BucketSpec{ForProvider: exoscalev1.BucketParameters{
+					BucketName: "my-bucket"}},
+			},
+			returnError:    minio.ErrorResponse{StatusCode: http.StatusMovedPermanently, Message: "301 Moved Permanently"},
+			expectedResult: managed.ExternalObservation{},
+			expectedError:  "mismatching endpointURL and zone, or bucket exists already in a different region, try changing bucket name: 301 Moved Permanently",
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			currFn := bucketExistsFn
+			defer func() {
+				bucketExistsFn = currFn
+			}()
+			bucketExistsFn = func(ctx context.Context, mc *minio.Client, bucketName string) (bool, error) {
+				return tc.bucketExists, tc.returnError
+			}
+			p := ProvisioningPipeline{}
+			result, err := p.Observe(logr.NewContext(context.Background(), logr.Discard()), tc.givenBucket)
+			if tc.expectedError != "" {
+				assert.EqualError(t, err, tc.expectedError)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectedResult, result)
+			assert.Equal(t, tc.expectedBucketObservation, tc.givenBucket.Status.AtProvider)
+		})
+	}
+}

--- a/operator/bucketcontroller/pipeline.go
+++ b/operator/bucketcontroller/pipeline.go
@@ -2,6 +2,7 @@ package bucketcontroller
 
 import (
 	"context"
+
 	exoscalev1 "github.com/vshn/provider-exoscale/apis/exoscale/v1"
 
 	"github.com/crossplane/crossplane-runtime/pkg/event"
@@ -34,3 +35,5 @@ func NewProvisioningPipeline(kube client.Client, recorder event.Recorder, minioC
 func fromManaged(mg resource.Managed) *exoscalev1.Bucket {
 	return mg.(*exoscalev1.Bucket)
 }
+
+const lockAnnotation = exoscalev1.Group + "/lock"

--- a/test/controllerconfig-exoscale.yaml
+++ b/test/controllerconfig-exoscale.yaml
@@ -5,3 +5,6 @@ metadata:
   name: providerconfig-exoscale
 spec:
   imagePullPolicy: IfNotPresent
+  env:
+    - name: LOG_LEVEL
+      value: "1"

--- a/test/e2e/provider/00-assert.yaml
+++ b/test/e2e/provider/00-assert.yaml
@@ -6,6 +6,8 @@ apiVersion: exoscale.crossplane.io/v1
 kind: Bucket
 metadata:
   name: e2e-test-bucket
+  annotations:
+    exoscale.crossplane.io/lock: claimed
 spec:
   deletionPolicy: Delete
   forProvider:


### PR DESCRIPTION
## Summary

* Adds suggestion what to do when we get an access denied error or 301
* Prevents adoption of existing bucket on new bucket object creation, if we have access
* Fixes #21 

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [x] Link this PR to related issues.
- [x] I have run `make test-e2e` and e2e tests pass successfully
- [x] Check if same-bucket-name in another region is allowed

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
