### PR TITLE
Make connection Secret immutable

### DIFF
--- a/operator/iamkeycontroller/create.go
+++ b/operator/iamkeycontroller/create.go
@@ -3,6 +3,8 @@ package iamkeycontroller
 import (
 	"context"
 	"fmt"
+	"strings"
+
 	pipeline "github.com/ccremer/go-command-pipeline"
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/pkg/event"
@@ -14,9 +16,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/utils/pointer"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"strings"
 )
 
 // Create implements managed.ExternalClient.
@@ -115,6 +117,7 @@ func (p *IAMKeyPipeline) createCredentialsSecret(ctx *pipelineContext) error {
 		for k, v := range toConnectionDetails(ctx.iamExoscaleKey) {
 			secret.Data[k] = v
 		}
+		secret.Immutable = pointer.Bool(true)
 		return controllerutil.SetOwnerReference(ctx.iamKey, secret, p.kube.Scheme())
 	})
 	if err != nil {

--- a/test/e2e/provider/00-assert.yaml
+++ b/test/e2e/provider/00-assert.yaml
@@ -5,8 +5,7 @@ kind: TestAssert
 apiVersion: exoscale.crossplane.io/v1
 kind: Bucket
 metadata:
-  annotations:
-    kuttl: '01-install'
+  name: e2e-test-bucket
 spec:
   deletionPolicy: Delete
   forProvider:

--- a/test/e2e/provider/00-install-bucket.yaml
+++ b/test/e2e/provider/00-install-bucket.yaml
@@ -2,8 +2,6 @@
 apiVersion: exoscale.crossplane.io/v1
 kind: Bucket
 metadata:
-  annotations:
-    kuttl: '01-install'
   name: e2e-test-bucket
 spec:
   forProvider:

--- a/test/e2e/provider/01-assert.yaml
+++ b/test/e2e/provider/01-assert.yaml
@@ -7,7 +7,6 @@ kind: IAMKey
 metadata:
   annotations:
     crossplane.io/external-name: e2e-test-kuttl-iam-key
-    kuttl: '00-install'
   finalizers:
     - finalizer.managedresource.crossplane.io
   name: e2e-test-kuttl-iam-key
@@ -54,3 +53,4 @@ metadata:
       kind: IAMKey
       name: e2e-test-kuttl-iam-key
 type: connection.crossplane.io/v1alpha1
+immutable: true

--- a/test/e2e/provider/01-install-iamkey.yaml
+++ b/test/e2e/provider/01-install-iamkey.yaml
@@ -3,8 +3,6 @@ apiVersion: exoscale.crossplane.io/v1
 kind: IAMKey
 metadata:
   name: e2e-test-kuttl-iam-key
-  annotations:
-    kuttl: '00-install'
 spec:
   forProvider:
     keyName: e2e-test-kuttl-iam-key


### PR DESCRIPTION
## Summary

This makes the created Secret [immutable](https://kubernetes.io/docs/concepts/configuration/secret/#secret-immutable). In the case of Exoscale IAM key, we need to recreate the key anyway since they're immutable as well.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [x] Link this PR to related issues.
- [x] I have run `make test-e2e` and e2e tests pass successfully

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
