### PR TITLE
Add "endpoint" field to bucket

### DIFF
--- a/apis/exoscale/v1/bucket_types.go
+++ b/apis/exoscale/v1/bucket_types.go
@@ -30,10 +30,8 @@ type BucketParameters struct {
 
 	// +kubebuilder:validation:Required
 
-	// EndpointURL is the URL where to create the bucket.
-	// If the scheme is omitted (`http/s`), HTTPS is assumed.
-	// Changing the endpoint after initial creation might have no effect.
-	EndpointURL string `json:"endpointURL"`
+	// Deprecated: Only here for compatibility with legacy Bucket objects
+	EndpointURL string `json:"endpointURL,omitempty"`
 
 	// +kubebuilder:validation:Required
 
@@ -67,6 +65,8 @@ type BucketObservation struct {
 // BucketStatus represents the observed state of a Bucket.
 type BucketStatus struct {
 	xpv1.ResourceStatus `json:",inline"`
+	Endpoint            string            `json:"endpoint,omitempty"`
+	EndpointURL         string            `json:"endpointURL,omitempty"`
 	AtProvider          BucketObservation `json:"atProvider,omitempty"`
 }
 

--- a/docs/modules/ROOT/examples/exoscale_bucket.yaml
+++ b/docs/modules/ROOT/examples/exoscale_bucket.yaml
@@ -6,7 +6,6 @@ spec:
   forProvider:
     bucketDeletionPolicy: DeleteIfEmpty
     bucketName: bucket.test.1
-    endpointURL: sos-ch-gva-2.exo.io
     zone: ch-gva-2
   providerConfigRef:
     name: provider-config

--- a/generate_sample.go
+++ b/generate_sample.go
@@ -107,7 +107,6 @@ func newBucketSample() *exoscalev1.Bucket {
 				ProviderConfigReference: &xpv1.Reference{Name: "provider-config"},
 			},
 			ForProvider: exoscalev1.BucketParameters{
-				EndpointURL:          "sos-ch-gva-2.exo.io",
 				BucketName:           "bucket-local-dev",
 				Zone:                 "ch-gva-2",
 				BucketDeletionPolicy: exoscalev1.DeleteIfEmpty,

--- a/package/crds/exoscale.crossplane.io_buckets.yaml
+++ b/package/crds/exoscale.crossplane.io_buckets.yaml
@@ -91,9 +91,8 @@ spec:
                       name across the platform or zone.
                     type: string
                   endpointURL:
-                    description: EndpointURL is the URL where to create the bucket.
-                      If the scheme is omitted (`http/s`), HTTPS is assumed. Changing
-                      the endpoint after initial creation might have no effect.
+                    description: 'Deprecated: Only here for compatibility with legacy
+                      Bucket objects'
                     type: string
                   zone:
                     description: Zone is the name of the zone where the bucket shall
@@ -101,7 +100,6 @@ spec:
                       be changed after bucket is created.
                     type: string
                 required:
-                - endpointURL
                 - zone
                 type: object
               providerConfigRef:
@@ -318,6 +316,10 @@ spec:
                   - type
                   type: object
                 type: array
+              endpoint:
+                type: string
+              endpointURL:
+                type: string
             type: object
         required:
         - spec

--- a/samples/exoscale.crossplane.io_bucket.yaml
+++ b/samples/exoscale.crossplane.io_bucket.yaml
@@ -7,7 +7,6 @@ spec:
   forProvider:
     bucketDeletionPolicy: DeleteIfEmpty
     bucketName: bucket-local-dev
-    endpointURL: sos-ch-gva-2.exo.io
     zone: ch-gva-2
   providerConfigRef:
     name: provider-config

--- a/test/e2e/provider/00-assert.yaml
+++ b/test/e2e/provider/00-assert.yaml
@@ -13,7 +13,6 @@ spec:
   forProvider:
     bucketName: e2e-test-kuttl-provider-exoscale
     bucketDeletionPolicy: DeleteAll
-    endpointURL: sos-ch-gva-2.exo.io
     zone: ch-gva-2
   providerConfigRef:
     name: provider-config
@@ -27,4 +26,6 @@ status:
     - reason: ReconcileSuccess
       status: 'True'
       type: Synced
+  endpoint: sos-ch-gva-2.exo.io
+  endpointURL: https://sos-ch-gva-2.exo.io
 ---

--- a/test/e2e/provider/00-install-bucket.yaml
+++ b/test/e2e/provider/00-install-bucket.yaml
@@ -7,7 +7,6 @@ spec:
   forProvider:
     bucketName: e2e-test-kuttl-provider-exoscale
     bucketDeletionPolicy: DeleteAll
-    endpointURL: sos-ch-gva-2.exo.io
     zone: ch-gva-2
   providerConfigRef:
     name: provider-config


### PR DESCRIPTION
Due to apparent limitations of Crossplane compositions we need both an "endpoint" and an "endpointURL" field. "endpoint" will contain the simple endpoint host name, while endpointURL will contain the full URL (https://...).

Context: https://ticket.vshn.net/browse/APPCAT-226