### PR TITLE
Implement Updating of PostgreSQL instances

### DIFF
--- a/operator/mapper/alias.go
+++ b/operator/mapper/alias.go
@@ -16,10 +16,19 @@ type BackupSchedule = struct {
 	BackupMinute *int64 `json:"backup-minute,omitempty"`
 }
 
-// MaintenanceSchedule is a type alias for the embedded struct in opai.CreateDbaasServicePgJSONRequestBody.
-type MaintenanceSchedule = struct {
+// MaintenanceScheduleCreateRequest is a type alias for the embedded struct in opai.CreateDbaasServicePgJSONRequestBody.
+type MaintenanceScheduleCreateRequest = struct {
 	// Day of week for installing updates
 	Dow oapi.CreateDbaasServicePgJSONBodyMaintenanceDow `json:"dow"`
+
+	// Time for installing updates, UTC
+	Time string `json:"time"`
+}
+
+// MaintenanceScheduleUpdateRequest is a type alias for the embedded struct in opai.UpdateDbaasServicePgJSONRequestBody.
+type MaintenanceScheduleUpdateRequest = struct {
+	// Day of week for installing updates
+	Dow oapi.UpdateDbaasServicePgJSONBodyMaintenanceDow `json:"dow"`
 
 	// Time for installing updates, UTC
 	Time string `json:"time"`
@@ -33,9 +42,16 @@ func toBackupSchedule(day exoscalev1.TimeOfDay) (BackupSchedule, error) {
 	}, err
 }
 
-func toMaintenanceSchedule(spec exoscalev1.MaintenanceSpec) MaintenanceSchedule {
-	return MaintenanceSchedule{
+func toMaintenanceScheduleCreateRequest(spec exoscalev1.MaintenanceSpec) MaintenanceScheduleCreateRequest {
+	return MaintenanceScheduleCreateRequest{
 		Dow:  oapi.CreateDbaasServicePgJSONBodyMaintenanceDow(spec.DayOfWeek),
+		Time: spec.TimeOfDay.String(),
+	}
+}
+
+func toMaintenanceScheduleUpdateRequest(spec exoscalev1.MaintenanceSpec) MaintenanceScheduleUpdateRequest {
+	return MaintenanceScheduleUpdateRequest{
+		Dow:  oapi.UpdateDbaasServicePgJSONBodyMaintenanceDow(spec.DayOfWeek),
 		Time: spec.TimeOfDay.String(),
 	}
 }

--- a/operator/mapper/alias_test.go
+++ b/operator/mapper/alias_test.go
@@ -64,24 +64,24 @@ func Test_toBackupSchedule(t *testing.T) {
 func Test_toMaintenanceSchedule(t *testing.T) {
 	tests := map[string]struct {
 		givenSpec      exoscalev1.MaintenanceSpec
-		expectedResult MaintenanceSchedule
+		expectedResult MaintenanceScheduleCreateRequest
 	}{
 		"Disabled": {
 			givenSpec:      exoscalev1.MaintenanceSpec{TimeOfDay: "0:00:00", DayOfWeek: "never"},
-			expectedResult: MaintenanceSchedule{Time: "0:00:00", Dow: "never"},
+			expectedResult: MaintenanceScheduleCreateRequest{Time: "0:00:00", Dow: "never"},
 		},
 		"SameWeekDay": {
 			givenSpec:      exoscalev1.MaintenanceSpec{TimeOfDay: "0:00:00", DayOfWeek: "monday"},
-			expectedResult: MaintenanceSchedule{Time: "0:00:00", Dow: "monday"},
+			expectedResult: MaintenanceScheduleCreateRequest{Time: "0:00:00", Dow: "monday"},
 		},
 		"SameTime": {
 			givenSpec:      exoscalev1.MaintenanceSpec{TimeOfDay: "12:34:56", DayOfWeek: "monday"},
-			expectedResult: MaintenanceSchedule{Time: "12:34:56", Dow: "monday"},
+			expectedResult: MaintenanceScheduleCreateRequest{Time: "12:34:56", Dow: "monday"},
 		},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			result := toMaintenanceSchedule(tc.givenSpec)
+			result := toMaintenanceScheduleCreateRequest(tc.givenSpec)
 			assert.Equal(t, tc.expectedResult, result)
 		})
 	}

--- a/operator/mapper/conditions.go
+++ b/operator/mapper/conditions.go
@@ -1,0 +1,16 @@
+package mapper
+
+import (
+	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
+)
+
+// FindStatusCondition returns the condition by the given type if present.
+// If not found, it returns nil.
+func FindStatusCondition(c []xpv1.Condition, conditionType xpv1.ConditionType) *xpv1.Condition {
+	for _, condition := range c {
+		if condition.Type == conditionType {
+			return &condition
+		}
+	}
+	return nil
+}

--- a/operator/postgresqlcontroller/create.go
+++ b/operator/postgresqlcontroller/create.go
@@ -21,7 +21,7 @@ func (p *Pipeline) Create(ctx context.Context, mg resource.Managed) (managed.Ext
 	spec := pgInstance.Spec.ForProvider
 	mpr := &mapper.PostgreSQLMapper{}
 	body := oapi.CreateDbaasServicePgJSONBody{}
-	err := mpr.FromSpec(spec, &body)
+	err := mpr.FromSpecToCreateBody(spec, &body)
 	if err != nil {
 		return managed.ExternalCreation{}, errors.Wrap(err, "cannot map spec to API request")
 	}

--- a/operator/postgresqlcontroller/update.go
+++ b/operator/postgresqlcontroller/update.go
@@ -3,14 +3,32 @@ package postgresqlcontroller
 import (
 	"context"
 
+	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
+	"github.com/exoscale/egoscale/v2/oapi"
+	"github.com/vshn/provider-exoscale/operator/mapper"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 )
 
 // Update implements managed.ExternalClient.
 func (p *Pipeline) Update(ctx context.Context, mg resource.Managed) (managed.ExternalUpdate, error) {
 	log := controllerruntime.LoggerFrom(ctx)
-	log.V(1).Info("Updating resource (noop)")
+	log.V(1).Info("Updating resource")
+
+	pgInstance := fromManaged(mg)
+
+	spec := pgInstance.Spec.ForProvider
+	mpr := &mapper.PostgreSQLMapper{}
+	body := oapi.UpdateDbaasServicePgJSONRequestBody{}
+	err := mpr.FromSpecToUpdateBody(spec, &body)
+	if err != nil {
+		return managed.ExternalUpdate{}, errors.Wrap(err, "cannot map spec to API request")
+	}
+	resp, err := p.exo.UpdateDbaasServicePgWithResponse(ctx, oapi.DbaasServiceName(pgInstance.Name), body)
+	if err != nil {
+		return managed.ExternalUpdate{}, errors.Wrap(err, "cannot update instance")
+	}
+	log.V(1).Info("Response", "json", resp.JSON200)
 	return managed.ExternalUpdate{}, nil
 }

--- a/operator/postgresqlcontroller/webhook_test.go
+++ b/operator/postgresqlcontroller/webhook_test.go
@@ -44,3 +44,52 @@ func TestValidator_validatePGSettings(t *testing.T) {
 		})
 	}
 }
+func TestValidator_compareVersion(t *testing.T) {
+	tests := map[string]struct {
+		oldObservedVersion string
+		oldSpecVersion     string
+		newDesiredVersion  string
+		expectedError      string
+	}{
+		"NoChange_SameVersion": {
+			oldSpecVersion:     "14",
+			newDesiredVersion:  "14",
+			oldObservedVersion: "14.5",
+			expectedError:      "",
+		},
+		"NoChange_DifferentObservedVersion": {
+			oldSpecVersion:     "14",
+			newDesiredVersion:  "14",
+			oldObservedVersion: "15.1",
+			expectedError:      "",
+		},
+		"Change_ToSameObservedVersion": {
+			oldSpecVersion:     "14",
+			newDesiredVersion:  "15.1",
+			oldObservedVersion: "15.1",
+			expectedError:      "",
+		},
+		"Change_ToOtherValue": {
+			oldSpecVersion:     "14",
+			newDesiredVersion:  "15.2",
+			oldObservedVersion: "15.1",
+			expectedError:      "field is immutable after creation: 14 (old), 15.2 (changed)",
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			v := Validator{log: logr.Discard()}
+			oldObj := &exoscalev1.PostgreSQL{}
+			newObj := &exoscalev1.PostgreSQL{}
+			oldObj.Status.AtProvider.Version = tc.oldObservedVersion
+			oldObj.Spec.ForProvider.Version = tc.oldSpecVersion
+			newObj.Spec.ForProvider.Version = tc.newDesiredVersion
+			err := v.compareVersion(oldObj, newObj)
+			if tc.expectedError != "" {
+				assert.EqualError(t, err, tc.expectedError)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

* Implements the "Update" part of the API. Users can now update instances based on the spec
* The spec prevents modification of an instance of certain properties if the instance has been provisioned once.

Following properties are immutable by Exoscale API:
* `zone`
* `version` 

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [x] Link this PR to related issues.
- [ ] ~I have run `make test-e2e` and e2e tests pass successfully~ See #38 

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
