### PR TITLE
Enable output of golang-ci in the job logs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,11 +16,12 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
 
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+      - uses: actions/cache@v3
         with:
-          version: latest
-          args: --timeout 5m --verbose
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
 
       - name: Run linters
         run: make lint

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,8 @@ include Makefile.vars.mk
 # Crossplane packaging
 -include package/package.mk
 
+golangci_bin = $(go_bin)/golangci-lint
+
 .PHONY: help
 help: ## Show this help
 	@grep -E -h '\s##\s' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
@@ -53,9 +55,15 @@ vet: ## Run 'go vet' against code
 	go vet ./...
 
 .PHONY: lint
-lint: fmt vet generate ## All-in-one linting
+lint: generate fmt golangci-lint git-diff ## All-in-one linting
+
+git-diff:
 	@echo 'Check for uncommitted changes ...'
 	git diff --exit-code
+
+.PHONY: golangci-lint
+golangci-lint: $(golangci_bin) ## Run golangci linters
+	$(golangci_bin) run --timeout 5m --out-format colored-line-number ./...
 
 .PHONY: generate
 generate: ## Generate additional code and artifacts
@@ -92,3 +100,6 @@ run-operator: ## Run in Operator mode against your current kube context
 clean: .e2e-test-clean .package-clean .envtest-clean kind-clean ## Cleans local build artifacts
 	rm -rf docs/node_modules $(docs_out_dir) dist .cache .work
 	$(DOCKER_CMD) rmi $(CONTAINER_IMG) || true
+
+$(golangci_bin): | $(go_bin)
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$(go_bin)"

--- a/operator/iamkeycontroller/update.go
+++ b/operator/iamkeycontroller/update.go
@@ -2,6 +2,7 @@ package iamkeycontroller
 
 import (
 	"context"
+
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	controllerruntime "sigs.k8s.io/controller-runtime"


### PR DESCRIPTION
## Summary

* Run golangci-lint from makefile
* Enable printing of file and line number (GitHub annotations still work)
* Downloads golangci-lint if not available in `.work/bin`

Example run with a failed linting error: https://github.com/vshn/provider-exoscale/actions/runs/3322352402/jobs/5491250517

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [x] Link this PR to related issues.


<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
