### PR TITLE
Fix panic in node state mapping

### DIFF
--- a/operator/mapper/alias.go
+++ b/operator/mapper/alias.go
@@ -36,11 +36,19 @@ func ToSlice(arr *[]string) []string {
 }
 
 func ToNodeStates(states *[]oapi.DbaasNodeState) []exoscalev1.NodeState {
+	if states == nil {
+		return nil
+	}
 	s := make([]exoscalev1.NodeState, len(*states))
 	for i, state := range *states {
+		var role oapi.DbaasNodeStateRole
+		if state.Role != nil {
+			role = *state.Role
+		}
+
 		s[i] = exoscalev1.NodeState{
 			Name:  state.Name,
-			Role:  *state.Role,
+			Role:  role,
 			State: state.State,
 		}
 	}


### PR DESCRIPTION
## Summary

Node states are not guaranteed to have a state. For example Kafka nodes don't. In any case we should never panic in the node state mapping

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [x] I have run `make test-e2e` and e2e tests pass successfully

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
