### PR TITLE
Increase timeouts for Kafka e2e tests

### DIFF
--- a/test/e2e/kafka/00-assert.yaml
+++ b/test/e2e/kafka/00-assert.yaml
@@ -1,6 +1,6 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-timeout: 600
+timeout: 900
 ---
 apiVersion: exoscale.crossplane.io/v1
 kind: Kafka

--- a/test/e2e/kafka/01-assert.yaml
+++ b/test/e2e/kafka/01-assert.yaml
@@ -1,3 +1,7 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 300
+---
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/test/e2e/kafka/02-assert.yaml
+++ b/test/e2e/kafka/02-assert.yaml
@@ -1,3 +1,7 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 300
+---
 apiVersion: batch/v1
 kind: Job
 metadata:


### PR DESCRIPTION
This should fix the flaky tests caused by slow CI runners

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [x] I have run `make test-e2e` and e2e tests pass successfully

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
