### PR TITLE
Revise dbaas settings compare function

### DIFF
--- a/operator/kafkacontroller/observe_test.go
+++ b/operator/kafkacontroller/observe_test.go
@@ -337,7 +337,7 @@ func TestObserve_Outdated_Settings(t *testing.T) {
 	})
 	instance.Spec.ForProvider.KafkaSettings = setting
 	found := sampleAPIKafka("foo")
-	found.KafkaRestSettings = &map[string]interface{}{
+	found.KafkaSettings = &map[string]interface{}{
 		"foo":   "bar",
 		"count": 2,
 	}
@@ -351,7 +351,7 @@ func TestObserve_Outdated_Settings(t *testing.T) {
 		assert.NoError(t, err)
 		require.NotNil(t, res)
 		assert.True(t, res.ResourceExists, "report resource exits")
-		assert.False(t, res.ResourceUpToDate, "report resource not uptodate")
+		assert.False(t, res.ResourceUpToDate, "report resource not updated")
 	})
 }
 

--- a/operator/mapper/dbaas.go
+++ b/operator/mapper/dbaas.go
@@ -31,17 +31,18 @@ func set(s []string) map[string]struct{} {
 	return m
 }
 
-func CompareSettings(a, b runtime.RawExtension) bool {
-	sa, err := ToMap(a)
+// CompareSettings compares 2 instances of service settings
+// Some DBaaS add default settings to their services, which lead to unequal settings between
+// managed and provider's resource
+// Ignore added provider configuration
+func CompareSettings(managed, provider runtime.RawExtension) bool {
+	sa, err := ToMap(managed)
 	if err != nil {
 		// we have to assume they're not the same
 		return false
 	}
-	sb, err := ToMap(b)
+	sb, err := ToMap(provider)
 	if err != nil {
-		return false
-	}
-	if len(sa) != len(sb) {
 		return false
 	}
 	for k, va := range sa {

--- a/operator/mapper/dbaas_test.go
+++ b/operator/mapper/dbaas_test.go
@@ -134,7 +134,7 @@ func TestCompareSettings(t *testing.T) {
 		"BothEmpty":       {givenSpec: "", observedSpec: nil, expected: true},
 		"Null":            {givenSpec: "null", observedSpec: nil, expected: true},
 		"EmptyObserved":   {givenSpec: `{"key":"value"}`, observedSpec: map[string]interface{}{}, expected: false},
-		"EmptySpec":       {givenSpec: ``, observedSpec: map[string]interface{}{"key": "value"}, expected: false},
+		"EmptySpec":       {givenSpec: ``, observedSpec: map[string]interface{}{"key": "value"}, expected: true},
 		"EmptySpecObject": {givenSpec: `{}`, observedSpec: nil, expected: true},
 		"SameString":      {givenSpec: `{"string":"value"}`, observedSpec: map[string]interface{}{"string": "value"}, expected: true},
 		"SameNumber":      {givenSpec: `{"number":0.5}`, observedSpec: map[string]interface{}{"number": 0.5}, expected: true},


### PR DESCRIPTION
## Summary

* Some DBaaS such as OpenSearch or MySQL are having default settings from provider. We need to make sure we don't trigger a never ending update on the provider resource.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] I have update the integration tests
- [x] I have run `make test-e2e` and e2e tests pass successfully

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
