### PR TITLE
Add missing resources to e2e-test-clean

### DIFF
--- a/test/local.mk
+++ b/test/local.mk
@@ -136,6 +136,9 @@ test-e2e: $(kuttl_bin) $(mc_bin) local-install provider-config ## E2E tests
 		kubectl delete iamkeys --all; \
 		kubectl delete postgresql --all; \
 		kubectl delete mysql --all; \
+		kubectl delete redis --all; \
+		kubectl delete kafka --all; \
+		kubectl delete opensearch --all; \
 	else \
 		echo "no kubeconfig found"; \
 	fi


### PR DESCRIPTION
## Summary

Add missing resources to e2e-test-clean

## Checklist

- [X] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [X] I have run `make test-e2e` and e2e tests pass successfully

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
