### PR TITLE
bugfix: return error when iam key or secret are not present

### DIFF
--- a/operator/iamkeycontroller/connector.go
+++ b/operator/iamkeycontroller/connector.go
@@ -12,13 +12,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-type IAMKeyConnector struct {
+type connector struct {
 	Kube     client.Client
 	Recorder event.Recorder
 }
 
 // Connect implements managed.ExternalConnecter.
-func (c *IAMKeyConnector) Connect(ctx context.Context, mg resource.Managed) (managed.ExternalClient, error) {
+func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.ExternalClient, error) {
 	ctx = pipeline.MutableContext(ctx)
 	log := ctrl.LoggerFrom(ctx)
 	log.V(1).Info("Connecting resource")

--- a/operator/iamkeycontroller/pipeline.go
+++ b/operator/iamkeycontroller/pipeline.go
@@ -2,6 +2,8 @@ package iamkeycontroller
 
 import (
 	"context"
+	"errors"
+
 	exoscalesdk "github.com/exoscale/egoscale/v2"
 	exoscalev1 "github.com/vshn/provider-exoscale/apis/exoscale/v1"
 
@@ -61,11 +63,17 @@ func NewPipeline(client client.Client, recorder event.Recorder, exoscaleClient *
 	}
 }
 
-func toConnectionDetails(iamKey *exoscalesdk.IAMAccessKey) managed.ConnectionDetails {
+func toConnectionDetails(iamKey *exoscalesdk.IAMAccessKey) (managed.ConnectionDetails, error) {
+	if iamKey.Key == nil {
+		return nil, errors.New("iamKey key not found in connection details")
+	}
+	if iamKey.Secret == nil {
+		return nil, errors.New("iamKey secret not found in connection details")
+	}
 	return map[string][]byte{
 		exoscalev1.AccessKeyIDName:     []byte(*iamKey.Key),
 		exoscalev1.SecretAccessKeyName: []byte(*iamKey.Secret),
-	}
+	}, nil
 }
 
 func fromManaged(mg resource.Managed) *exoscalev1.IAMKey {

--- a/operator/iamkeycontroller/setup.go
+++ b/operator/iamkeycontroller/setup.go
@@ -21,7 +21,7 @@ func SetupController(mgr ctrl.Manager) error {
 
 	r := managed.NewReconciler(mgr,
 		resource.ManagedKind(exoscalev1.IAMKeyGroupVersionKind),
-		managed.WithExternalConnecter(&IAMKeyConnector{
+		managed.WithExternalConnecter(&connector{
 			Kube:     mgr.GetClient(),
 			Recorder: recorder,
 		}),


### PR DESCRIPTION
bugfix: return an error when iam key or secret are not present when setting connection details

## Checklist

- [X] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [X] PR contains a single logical change (to build a better changelog).
- [X] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
