### PR TITLE
bypass governance retention when deleting s3 bucket

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,6 +8,7 @@
       The PR has a meaningful description that sums up the change. It will be
       linked in the changelog.
 - [ ] PR contains a single logical change (to build a better changelog).
+- [ ] I have run successfully `make test-e2e` locally.
 - [ ] Update the documentation.
 - [ ] Categorize the PR by adding one of the labels:
       `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`

--- a/operator/bucketcontroller/delete.go
+++ b/operator/bucketcontroller/delete.go
@@ -3,6 +3,7 @@ package bucketcontroller
 import (
 	"context"
 	"fmt"
+
 	pipeline "github.com/ccremer/go-command-pipeline"
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/pkg/event"
@@ -55,7 +56,9 @@ func (p *ProvisioningPipeline) deleteAllObjects(ctx *pipelineContext) error {
 		}
 	}()
 
-	for obj := range p.minioClient.RemoveObjects(ctx, bucketName, objectsCh, minio.RemoveObjectsOptions{GovernanceBypass: true}) {
+	// s3 seems to use the default retention governance mode, which causes bucket deletion to fail, unless bypassing governance retention
+	// https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lock-overview.html
+	for obj := range p.minioClient.RemoveObjects(ctx, bucketName, objectsCh, minio.RemoveObjectsOptions{GovernanceBypass: false}) {
 		return fmt.Errorf("object %q cannot be removed: %w", obj.ObjectName, obj.Err)
 	}
 	return nil

--- a/operator/bucketcontroller/delete.go
+++ b/operator/bucketcontroller/delete.go
@@ -56,12 +56,26 @@ func (p *ProvisioningPipeline) deleteAllObjects(ctx *pipelineContext) error {
 		}
 	}()
 
-	// s3 seems to use the default retention governance mode, which causes bucket deletion to fail, unless bypassing governance retention
-	// https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lock-overview.html
-	for obj := range p.minioClient.RemoveObjects(ctx, bucketName, objectsCh, minio.RemoveObjectsOptions{GovernanceBypass: false}) {
+	bypassGovernance, err := p.isBucketLockEnabled(ctx, bucketName)
+	if err != nil {
+		log.Error(err, "not able to determine ObjectLock status for bucket", "bucket", bucketName)
+	}
+
+	for obj := range p.minioClient.RemoveObjects(ctx, bucketName, objectsCh, minio.RemoveObjectsOptions{GovernanceBypass: bypassGovernance}) {
 		return fmt.Errorf("object %q cannot be removed: %w", obj.ObjectName, obj.Err)
 	}
 	return nil
+}
+
+func (p *ProvisioningPipeline) isBucketLockEnabled(ctx context.Context, bucketName string) (bool, error) {
+	_, mode, _, _, err := p.minioClient.GetObjectLockConfig(ctx, bucketName)
+	if err != nil && err.Error() == "Object Lock configuration does not exist for this bucket" {
+		return false, nil
+	} else if err != nil {
+		return false, err
+	}
+	// If there's an objectLockConfig it could still be disabled...
+	return mode != nil, nil
 }
 
 // deleteS3Bucket deletes the bucket.

--- a/test/local.mk
+++ b/test/local.mk
@@ -128,6 +128,11 @@ test-e2e: $(kuttl_bin) $(mc_bin) local-install provider-config ## E2E tests
 	@rm -f kubeconfig
 # kuttl leaves kubeconfig garbage: https://github.com/kudobuilder/kuttl/issues/297
 
+run-single-e2e: export KUBECONFIG = $(KIND_KUBECONFIG)
+run-single-e2e: $(kuttl_bin) $(mc_bin) local-install provider-config ## Run specific e2e test with `run-single-e2e test=$name`
+	GOBIN=$(go_bin) $(kuttl_bin) test ./test/e2e --config ./test/e2e/kuttl-test.yaml --suppress-log=Events --test $(test)
+	@rm -f kubeconfig
+
 .PHONY: .e2e-test-clean
 .e2e-test-clean: export KUBECONFIG = $(KIND_KUBECONFIG)
 .e2e-test-clean:


### PR DESCRIPTION
## Summary 

s3 seems to use the default retention governance mode, which causes bucket deletion to fail unless we bypass the governance retention.

https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lock-overview.html

## Checklist

- [X] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [X] PR contains a single logical change (to build a better changelog).
- [X] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [X] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
