### PR TITLE
Remove SOS IAMkey access tag

### DIFF
--- a/operator/iamkeycontroller/create.go
+++ b/operator/iamkeycontroller/create.go
@@ -73,8 +73,7 @@ func (p *IAMKeyPipeline) createIAMKey(ctx *pipelineContext) error {
 		// Allowed object storage operations on the new IAM key
 		// Some permissions are excluded such as create and list all sos buckets.
 		exoscalesdk.CreateIAMAccessKeyWithOperations(IAMKeyAllowedOperations),
-		// The tag and resource are used to limit the permissions to object storage
-		exoscalesdk.CreateIAMAccessKeyWithTags([]string{SOSResourceDomain}),
+		// Limit the permissions to the provided object storage resources
 		exoscalesdk.CreateIAMAccessKeyWithResources(keyResources),
 	}
 


### PR DESCRIPTION
Setting the sos tag will ignore any set oprations and will allow all SOS operations, which is not what we want.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] I have run successfully `make test-e2e` locally.
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
