### PR TITLE
Pin `up` cli to v0.15.0

### DIFF
--- a/package/package.mk
+++ b/package/package.mk
@@ -13,9 +13,11 @@ $(crossplane_bin): | $(go_bin)
 
 # Install up plugin
 $(up_bin):export GOBIN = $(go_bin)
+$(up_bin):export VERSION=v0.15.0
 $(up_bin): | $(go_bin)
 	curl -sL "https://cli.upbound.io" | sh
 	@mv up $@
+	$(up_bin) --version
 
 .PHONY: package
 package: ## All-in-one packaging and releasing


### PR DESCRIPTION
The CI broke after the upgrade to v0.16.0




## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
