### PR TITLE
fixing e2e tests 

### DIFF
--- a/operator/iamkeycontroller/observe.go
+++ b/operator/iamkeycontroller/observe.go
@@ -89,6 +89,8 @@ func (p *IAMKeyPipeline) Observe(ctx context.Context, mg resource.Managed) (mana
 
 	if iamKey.Status.AtProvider.RoleID == "" {
 		iamKey.Status.AtProvider.ServicesSpec.SOS.Buckets = getBuckets(*pctx.iamExoscaleKey.Resources)
+	} else {
+		iamKey.Status.AtProvider.ServicesSpec.SOS.Buckets = iamKey.Spec.ForProvider.Services.SOS.Buckets
 	}
 
 	connDetails, err := toConnectionDetails(pctx.iamExoscaleKey)


### PR DESCRIPTION
Adding logic to IamKey controller, so  e2e tests pass. This must be handled like to, because we need to support legacy keys as well
