### PR TITLE
Fix silent listing failure in deleteAllObjects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,4 +104,4 @@ clean: .e2e-test-clean .envtest-clean kind-clean ## Cleans local build artifacts
 	$(DOCKER_CMD) rmi $(CONTAINER_IMG) || true
 
 $(golangci_bin): | $(go_bin)
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$(go_bin)"
+	curl -sSfL https://golangci-lint.run/install.sh | sh -s -- -b "$(go_bin)"

--- a/operator/bucketcontroller/delete.go
+++ b/operator/bucketcontroller/delete.go
@@ -44,14 +44,16 @@ func (p *ProvisioningPipeline) deleteAllObjects(ctx *pipelineContext) error {
 	bucketName := ctx.bucket.Status.AtProvider.BucketName
 
 	objectsCh := make(chan minio.ObjectInfo)
+	var listObjectErr error
 
 	// Send object names that are needed to be removed to objectsCh
 	go func() {
 		defer close(objectsCh)
 		for object := range p.minioClient.ListObjects(ctx, bucketName, minio.ListObjectsOptions{Recursive: true}) {
 			if object.Err != nil {
-				log.V(1).Info("warning: cannot list object", "key", object.Key, "error", object.Err)
-				continue
+				listObjectErr = object.Err
+
+				return
 			}
 			objectsCh <- object
 		}
@@ -65,6 +67,11 @@ func (p *ProvisioningPipeline) deleteAllObjects(ctx *pipelineContext) error {
 	for obj := range p.minioClient.RemoveObjects(ctx, bucketName, objectsCh, minio.RemoveObjectsOptions{GovernanceBypass: bypassGovernance}) {
 		return fmt.Errorf("object %q cannot be removed: %w", obj.ObjectName, obj.Err)
 	}
+
+	if listObjectErr != nil {
+		return fmt.Errorf("cannot list objects for deletion: %w", listObjectErr)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
`deleteAllObjects` streams objects from `ListObjects` into a goroutine and pipes them to RemoveObjects. If `ListObjects` returns an error mid-stream (e.g. auth failure, network issue), the original code did continue, silently ignoring the error. The channel closes with a partial object list, `RemoveObjects` deletes only those objects, and `deleteAllObjects` returns `nil` — a false success. The pipeline then calls `deleteS3Bucket` on a bucket that still contains objects.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] I have run successfully `make test-e2e` locally.
- [ ] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
